### PR TITLE
Adding Github Actions for building Windows, Mac executables

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         dotnet-version: 3.1.101
     - name: Publish with dotnet
-      run: dotnet publish --nologo --configuration Release --runtime netcoreapp3.0 --framework netcoreapp3.0 --no-self-contained
+      run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,27 +7,52 @@ on:
     branches: [ githubactions ]
 
 jobs:
-  build:
-
+  checkout:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    - name: Publish with dotnet
-      run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
-    - name: Zip files
-      run: zip -r ArtNetTimecodeConsole.zip ./ArtNetTimecodeConsole
-    - name: Upload folder
-      uses: actions/upload-artifact@v1
-      with:
-        name: folder
-        path: ./ArtNetTimecodeConsole
-    - name: Upload file
-      uses: actions/upload-artifact@v1
-      with:
-        name: file
-        path: ArtNetTimecodeConsole.zip
+      - uses: actions/checkout@v2
+      - uses: actions/upload-artifact@v1
+        name: checkout
+        path: .
+
+  publish-win-x64:
+    name: Publish Windows x64
+    needs: checkout
+    runs-on: ubuntu-latest
+    steps:
+      - name: download checkout
+        uses: actions/download-artifact@v1
+        with:
+          name: checkout 
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Publish win-x64
+        run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ArtNetTimecodeConsole-x64
+          path: ./ArtNetTimecodeConsole
+
+  publish-win-x86:
+    name: Publish Windows x86
+    needs: checkout
+    runs-on: ubuntu-latest
+    steps:
+      - name: download checkout
+        uses: actions/download-artifact@v1
+        with:
+          name: checkout 
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Publish win-x86
+        run: dotnet publish --nologo --configuration Release --runtime win-x86 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ArtNetTimecodeConsole-x86
+          path: ./ArtNetTimecodeConsole          

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/upload-artifact@v1
-        name: checkout
-        path: ${pwd}
+        with:
+          name: checkout
+          path: .
 
   publish-win-x64:
     name: Publish Windows x64

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -78,6 +78,7 @@ jobs:
         run: dotnet publish --nologo --configuration Release --runtime osx-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
       - name: Make Executable
         run: chmod ug+x ./ArtNetTimecodeConsole/ArtNetTimecode
+      - run: ls -la ./ArtNetTimecodeConsole
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/upload-artifact@v1
         name: checkout
-        path: ./
+        path: ${pwd}
 
   publish-win-x64:
     name: Publish Windows x64

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         dotnet-version: 3.1.101
     - name: Publish with dotnet
-      run: dotnet build --nologo --configuration Release --runtime netcoreapp3.0 --framework netcoreapp3.0 --no-self-contained
+      run: dotnet publish --nologo --configuration Release --runtime netcoreapp3.0 --framework netcoreapp3.0 --no-self-contained

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,7 +24,8 @@ jobs:
       - name: download checkout
         uses: actions/download-artifact@v1
         with:
-          name: checkout 
+          name: checkout
+          path: .
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
@@ -45,7 +46,8 @@ jobs:
       - name: download checkout
         uses: actions/download-artifact@v1
         with:
-          name: checkout 
+          name: checkout
+          path: .
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -76,8 +76,10 @@ jobs:
           dotnet-version: 3.1.101
       - name: Publish macOS-x86
         run: dotnet publish --nologo --configuration Release --runtime osx-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
+      -name: Make Executable
+        run: chmod ug+x ./ArtNetTimecodeConsole/ArtNetTimecode
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
           name: ArtNetTimecodeConsole-macOS-x64
-          path: ./ArtNetTimecodeConsole          
+          path: ./ArtNetTimecodeConsole

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,11 +18,6 @@ jobs:
       with:
         dotnet-version: 3.1.101
     - name: Publish with dotnet
-      run: dotnet publish --nologo \
-        --configuration Release \
-        --runtime win-x64 \
-        --framework netcoreapp3.0 \
-        --no-self-contained \
-        --output ./ArtNetTimecodeConsole
+      run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
     - name: Zip files
       run: zip ./ArtNetTimecodeConsole ArtNetTimecodeConsole.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -58,4 +58,26 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ArtNetTimecodeConsole-x86
+          path: ./ArtNetTimecodeConsole
+
+  publish-macOS-x64:
+    name: Publish macOS x64
+    needs: checkout
+    runs-on: ubuntu-latest
+    steps:
+      - name: download checkout
+        uses: actions/download-artifact@v1
+        with:
+          name: checkout
+          path: .
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Publish macOS-x86
+        run: dotnet publish --nologo --configuration Release --runtime osx-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ArtNetTimecodeConsole-macOS-x64
           path: ./ArtNetTimecodeConsole          

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -76,7 +76,7 @@ jobs:
           dotnet-version: 3.1.101
       - name: Publish macOS-x86
         run: dotnet publish --nologo --configuration Release --runtime osx-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
-      -name: Make Executable
+      - name: Make Executable
         run: chmod ug+x ./ArtNetTimecodeConsole/ArtNetTimecode
       - name: Upload artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,9 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ githubactions ]
+    branches: [ master ]
   pull_request:
-    branches: [ githubactions ]
+    branches: [ master ]
 
 jobs:
   checkout:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Publish with dotnet
       run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
     - name: Zip files
-      run: zip ./ArtNetTimecodeConsole ArtNetTimecodeConsole.zip
+      run: zip -r ArtNetTimecodeConsole.zip ./ArtNetTimecodeConsole

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,4 +18,11 @@ jobs:
       with:
         dotnet-version: 3.1.101
     - name: Publish with dotnet
-      run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained
+      run: dotnet publish --nologo \
+        --configuration Release \
+        --runtime win-x64 \
+        --framework netcoreapp3.0 \
+        --no-self-contained \
+        --output ./ArtNetTimecodeConsole
+    - name: Zip files
+      run: zip ./ArtNetTimecodeConsole ArtNetTimecodeConsole.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,10 +22,10 @@ jobs:
     - name: Zip files
       run: zip -r ArtNetTimecodeConsole.zip ./ArtNetTimecodeConsole
     - uses: actions/upload-artifact@v1
-        with:
-          name: folder
-          path: ./ArtNetTimecodeConsole
+      with:
+        name: folder
+        path: ./ArtNetTimecodeConsole
     - uses: actions/upload-artifact@v1
-        with:
-          name: file
-          path: ArtNetTimecodeConsole.zip
+       with:
+        name: file
+        path: ArtNetTimecodeConsole.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,3 +21,13 @@ jobs:
       run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
     - name: Zip files
       run: zip -r ArtNetTimecodeConsole.zip ./ArtNetTimecodeConsole
+    - name: Upload Publish Path
+      uses: actions/upload-artifact@v1
+        with:
+          name: folder
+          path: ./ArtNetTimecodeConsole
+    - name: Upload Zip
+      uses: actions/upload-artifact@v1
+        with:
+          name: file
+          path: ArtNetTimecodeConsole.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/upload-artifact@v1
         name: checkout
-        path: .
+        path: ./
 
   publish-win-x64:
     name: Publish Windows x64

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         dotnet-version: 3.1.101
     - name: Publish with dotnet
-      run: dotnet build --nologo --configuration Release --runtime --framework netcoreapp3.0 --no-self-contained
+      run: dotnet build --nologo --configuration Release --runtime netcoreapp3.0 --framework netcoreapp3.0 --no-self-contained

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,13 +21,11 @@ jobs:
       run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
     - name: Zip files
       run: zip -r ArtNetTimecodeConsole.zip ./ArtNetTimecodeConsole
-    - name: Upload Publish Path
-      uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v1
         with:
           name: folder
           path: ./ArtNetTimecodeConsole
-    - name: Upload Zip
-      uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v1
         with:
           name: file
           path: ArtNetTimecodeConsole.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,11 +21,13 @@ jobs:
       run: dotnet publish --nologo --configuration Release --runtime win-x64 --framework netcoreapp3.0 --no-self-contained --output ./ArtNetTimecodeConsole
     - name: Zip files
       run: zip -r ArtNetTimecodeConsole.zip ./ArtNetTimecodeConsole
-    - uses: actions/upload-artifact@v1
+    - name: Upload folder
+      uses: actions/upload-artifact@v1
       with:
         name: folder
         path: ./ArtNetTimecodeConsole
-    - uses: actions/upload-artifact@v1
-       with:
+    - name: Upload file
+      uses: actions/upload-artifact@v1
+      with:
         name: file
         path: ArtNetTimecodeConsole.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,9 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ master ]
+    branches: [ githubactions ]
   pull_request:
-    branches: [ master ]
+    branches: [ githubactions ]
 
 jobs:
   build:
@@ -17,5 +17,5 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-    - name: Build with dotnet
-      run: dotnet build --configuration Release
+    - name: Publish with dotnet
+      run: dotnet build --nologo --configuration Release --runtime --framework netcoreapp3.0 --no-self-contained


### PR DESCRIPTION
Windows x86 and x64 work as intended and place Artifacts in the Action, macOS executable loses its permissions because of a bug in the download action https://github.com/actions/download-artifact/issues/14